### PR TITLE
Copy TestHelper to TestHarness/test (make Gradle happy)

### DIFF
--- a/TestHarness/test/org/aion/harness/integ/resources/TestHelper.java
+++ b/TestHarness/test/org/aion/harness/integ/resources/TestHelper.java
@@ -1,0 +1,104 @@
+package org.aion.harness.integ.resources;
+
+import java.io.File;
+import java.io.IOException;
+import org.aion.harness.main.LocalNode;
+import org.aion.harness.main.Network;
+import org.aion.harness.main.NodeConfigurations;
+import org.aion.harness.main.NodeConfigurations.DatabaseOption;
+import org.aion.harness.main.NodeFactory;
+import org.apache.commons.io.FileUtils;
+
+public class TestHelper {
+    private static final String WORKING_DIR = System.getProperty("user.dir");
+    public static final String EXPECTED_BUILD_LOCATION = WORKING_DIR + File.separator + "aion";
+    public static final Network DEFAULT_NETWORK = Network.CUSTOM;
+
+    public static File getDefaultDatabaseLocation() {
+        return new File(
+                EXPECTED_BUILD_LOCATION
+                        + File.separator
+                        + DEFAULT_NETWORK.string()
+                        + File.separator
+                        + "database");
+    }
+
+    public static File getDatabaseLocationByNetwork(Network network) {
+        return new File(
+                EXPECTED_BUILD_LOCATION
+                        + File.separator
+                        + network.string()
+                        + File.separator
+                        + "database");
+    }
+
+    public static LocalNode configureDefaultLocalNodeAndDoNotPreserveDatabase() throws IOException {
+        return getDefaultLocalNode(DEFAULT_NETWORK, DatabaseOption.DO_NOT_PRESERVE_DATABASE);
+    }
+
+    public static LocalNode configureDefaultLocalNodeToPreserveDatabase() throws IOException {
+        return getDefaultLocalNode(DEFAULT_NETWORK, DatabaseOption.PRESERVE_DATABASE);
+    }
+
+    public static LocalNode configureDefaultLocalNodeToPreserveDatabaseForNetwork(Network network)
+            throws IOException {
+        return getDefaultLocalNode(network, DatabaseOption.PRESERVE_DATABASE);
+    }
+
+    public static LocalNode configureDefaultLocalNodeForNetwork(Network network)
+            throws IOException {
+        return getDefaultLocalNode(network, DatabaseOption.DO_NOT_PRESERVE_DATABASE);
+    }
+
+    private static LocalNode getDefaultLocalNode(Network network, DatabaseOption databaseOption)
+            throws IOException {
+        File expectedBuildLocation = new File(EXPECTED_BUILD_LOCATION);
+
+        if (!expectedBuildLocation.exists()) {
+            System.err.println(
+                    "-------------------------------------------------------------------------------------------");
+            System.err.println(
+                    "ERROR: This test expects there to be an already built kernel for it to run against!");
+            System.err.println(
+                    "The built kernel is expected to be found at the following location: "
+                            + EXPECTED_BUILD_LOCATION);
+            System.err.println(
+                    "-------------------------------------------------------------------------------------------");
+            throw new IOException("Failed to find expected built kernel for test!");
+        }
+
+        if (!expectedBuildLocation.isDirectory()) {
+            System.err.println(
+                    "-------------------------------------------------------------------------------------------");
+            System.err.println(
+                    "ERROR: This test expects there to be an already built kernel for it to run against!");
+            System.err.println(
+                    "A file was found at the expected location but it is not a directory: "
+                            + EXPECTED_BUILD_LOCATION);
+            System.err.println("This must be the root directory of the built kernel.");
+            System.err.println(
+                    "-------------------------------------------------------------------------------------------");
+            throw new IOException("Failed to find expected built kernel for test!");
+        }
+
+        // Overwrites the config, fork and genesis files of each network.
+        FileUtils.copyDirectory(new File(WORKING_DIR + "/resources/config"), new File(EXPECTED_BUILD_LOCATION + "/config"));
+        overwriteIfTargetDirExists(new File(WORKING_DIR + "/resources/config/avmtestnet"), new File(EXPECTED_BUILD_LOCATION + "/avmtestnet/config"));
+        overwriteIfTargetDirExists(new File(WORKING_DIR + "/resources/config/conquest"), new File(EXPECTED_BUILD_LOCATION + "/conquest/config"));
+        overwriteIfTargetDirExists(new File(WORKING_DIR + "/resources/config/custom"), new File(EXPECTED_BUILD_LOCATION + "/custom/config"));
+        overwriteIfTargetDirExists(new File(WORKING_DIR + "/resources/config/mastery"), new File(EXPECTED_BUILD_LOCATION + "/mastery/config"));
+        overwriteIfTargetDirExists(new File(WORKING_DIR + "/resources/config/mainnet"), new File(EXPECTED_BUILD_LOCATION + "/mainnet/config"));
+
+        LocalNode node = NodeFactory.getNewLocalNodeInstance(NodeFactory.NodeType.JAVA_NODE);
+        node.configure(
+                NodeConfigurations.alwaysUseBuiltKernel(
+                        network, EXPECTED_BUILD_LOCATION, databaseOption));
+        return node;
+    }
+
+    private static void overwriteIfTargetDirExists(File source, File target) throws IOException {
+        if (target.exists()) {
+            FileUtils.copyDirectory(source, target);
+        }
+    }
+}


### PR DESCRIPTION
Gradle (and my IDE) didn't like that tests from `test` depended on a helper class from `integration-test`.  Fixed it by just copying the helper class in question into `test`

Before fix:

```
> Task :TestHarness:compileTestJava FAILED
/home/sergiu/repos/node_test_harness/TestHarness/test/org/aion/harness/unit/KernelTest.java:6: error: package org.aion.harness.integ.resources does not exist
import org.aion.harness.integ.resources.TestHelper;
                                       ^
/home/sergiu/repos/node_test_harness/TestHarness/test/org/aion/harness/unit/KernelTest.java:15: error: cannot find symbol
    private static final String KEYSTORE_PATH = TestHelper.EXPECTED_BUILD_LOCATION + File.separator + TestHelper.DEFAULT_NETWORK + File.separator + "keystore";
                                                ^
  symbol:   variable TestHelper
  location: class KernelTest
/home/sergiu/repos/node_test_harness/TestHarness/test/org/aion/harness/unit/KernelTest.java:15: error: cannot find symbol
    private static final String KEYSTORE_PATH = TestHelper.EXPECTED_BUILD_LOCATION + File.separator + TestHelper.DEFAULT_NETWORK + File.separator + "keystore";
                                                                                                      ^
  symbol:   variable TestHelper
  location: class KernelTest
/home/sergiu/repos/node_test_harness/TestHarness/test/org/aion/harness/unit/KernelTest.java:20: error: cannot find symbol
        this.node = (JavaNode) TestHelper.configureDefaultLocalNodeForNetwork(Network.CUSTOM);
                               ^
  symbol:   variable TestHelper
  location: class KernelTest
4 errors
```
After fix:

```
sergiu@aion-XPS-8930:~/repos/node_test_harness$ ./gradlew clean build 

> Task :TestHarness:test
[LockHolder] Locking /var/lock/AionTestHarness/locktest_3059491 until I exit.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 6.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/5.0/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 12s
9 actionable tasks: 8 executed, 1 up-to-date

```